### PR TITLE
(maint) Fix passing refs in constructor

### DIFF
--- a/lib/src/client_configuration.cc
+++ b/lib/src/client_configuration.cc
@@ -26,9 +26,9 @@ client_configuration::client_configuration(
         long connection_tmeout_ms_,
         unsigned int message_timeout_s_)
     : common_name {std::move(common_name_)},
-      client_type {client_type_},
-      broker_ws_uris {broker_ws_uris_},
-      certificates_dir {certificates_dir_},
+      client_type (client_type_),
+      broker_ws_uris (broker_ws_uris_),
+      certificates_dir (certificates_dir_),
       connection_timeout_ms {std::move(connection_tmeout_ms_)},
       message_timeout_s {std::move(message_timeout_s_)}
 {

--- a/lib/src/test_connection.cc
+++ b/lib/src/test_connection.cc
@@ -106,7 +106,7 @@ std::ofstream & operator<< (boost::nowide::ofstream& out,
 //
 
 connection_test::connection_test(const application_options& a_o)
-    : app_opt_ {a_o},
+    : app_opt_ (a_o),
       num_runs_ {app_opt_.connection_test_parameters.get<int>(conn_par::NUM_RUNS)},
       inter_run_pause_ms_ {static_cast<unsigned int>(
           app_opt_.connection_test_parameters.get<int>(conn_par::INTER_RUN_PAUSE_MS))},


### PR DESCRIPTION
Prior code tried to call constructors to initialize refs; this failed to
compile with GCC 4.8.5. Fix by using parentheses.
