### PR TITLE
(PCP-452) Configure Association timeout in connection test

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,17 @@ An example of configuration file is:
         "broker-ws-uris" : ["localhost",
                             "broker.example.com"],
         "connection-test-parameters" : {
-            "num-runs"                 : 1,
-            "inter-run-pause-ms"       : 5000,
-            "num-endpoints"            : 1,
-            "inter-endpoint-pause-ms"  : 150,
-            "concurrency"              : 1,
-            "endpoints-increment"      : 0,
-            "concurrency-increment"    : 0,
-            "ws-connection-timeout-ms" : 1000,
-            "association-ttl-s"        : 5,
-            "persist-connections"      : true
+            "num-runs"                   : 1,
+            "inter-run-pause-ms"         : 5000,
+            "num-endpoints"              : 1,
+            "inter-endpoint-pause-ms"    : 150,
+            "concurrency"                : 1,
+            "endpoints-increment"        : 0,
+            "concurrency-increment"      : 0,
+            "ws-connection-timeout-ms"   : 1000,
+            "association-timeout-s"      : 5,
+            "association-request-ttl-s"  : 10,
+            "persist-connections"        : true
         }
     }
 ```

--- a/doc/connection.md
+++ b/doc/connection.md
@@ -27,7 +27,8 @@ initialization (`ws-connection-timeout-ms` in milliseconds).
 
 PCP Association requests are sent with a given TTL (`association-ttl-s` in
 seconds). Note that such TTL is only meant for the processing of the request
-message; it's not referred to the entire association process.
+message; instead, the timeout for the entire association process can be
+specified by `association-timeout-s` (in seconds).
 
 Note that the `broker-ws-uris` is a global option, whereas all other options
 mentioned in this section are specific to the Connection Test and must be
@@ -42,8 +43,11 @@ Also, all options have integer arguments. The complete list of options is:
  - `endpoints-increment`
  - `concurrency-increment`
  - `ws-connection-timeout-ms`
- - `association-ttl-s`
+ - `association-timeout-s`
+ - `association-request-ttl-s`
  - `persist-connections`
+
+Once again, ALL options must be specified in your configuration file.
 
 ### Result Metrics
 
@@ -61,7 +65,8 @@ An example of output on standard out is the following:
       4 concurrent sets (+0 per run) of 100 endpoints (+100 per run)
       5 runs, 30000 ms pause between each run
       50 ms pause between each endpoint connection
-      WebSocket connection timeout 2500 ms; Association Request TTL 5 s
+      WebSocket connection timeout 2500 ms
+      Association timeout 10 s, Association Request TTL 5 s
       send WebSocket pings for keep-alive: yes
 
     Starting run 1: 4 concurrent sets of 100 endpoints

--- a/lib/inc/pcp-test/client_configuration.hpp
+++ b/lib/inc/pcp-test/client_configuration.hpp
@@ -7,11 +7,14 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace pcp_test {
 
 extern const long DEFAULT_CONNECTION_TIMEOUT_MS;
-extern const unsigned int DEFAULT_MESSAGE_TIMEOUT_S;
+extern const uint32_t DEFAULT_ASSOCIATION_TIMEOUT_S;
+extern const uint32_t DEFAULT_ASSOCIATION_REQUEST_TTL_S;
+extern const uint32_t DEFAULT_MESSAGE_TTL_S;
 
 struct client_configuration
 {
@@ -20,7 +23,9 @@ struct client_configuration
     const std::vector<std::string>& broker_ws_uris;
     const std::string& certificates_dir;
     long connection_timeout_ms;
-    unsigned int message_timeout_s;
+    uint32_t association_timeout_s;
+    uint32_t association_request_ttl_s;
+    uint32_t message_ttl_s;
     std::string ca;
     std::string crt;
     std::string key;
@@ -32,8 +37,10 @@ struct client_configuration
             const std::string& client_type,
             const std::vector<std::string>& broker_ws_uris,
             const std::string& certificate_dir,
-            long connection_tmeout_ms = DEFAULT_CONNECTION_TIMEOUT_MS,
-            unsigned int message_timeout_s = DEFAULT_MESSAGE_TIMEOUT_S);
+            long connection_tmeout_ms          = DEFAULT_CONNECTION_TIMEOUT_MS,
+            uint32_t association_timeout_s     = DEFAULT_ASSOCIATION_TIMEOUT_S,
+            uint32_t association_request_ttl_s = DEFAULT_ASSOCIATION_REQUEST_TTL_S,
+            uint32_t message_ttl_s             = DEFAULT_MESSAGE_TTL_S);
 };
 
 }  // namespace pcp_test

--- a/lib/inc/pcp-test/test_connection.hpp
+++ b/lib/inc/pcp-test/test_connection.hpp
@@ -64,7 +64,8 @@ class connection_test
     unsigned int inter_run_pause_ms_;
     unsigned int inter_endpoint_pause_ms_;
     unsigned int ws_connection_timeout_ms_;
-    unsigned int association_ttl_s_;
+    unsigned int association_timeout_s_;
+    unsigned int association_request_ttl_s_;
     connection_test_run current_run_;
     std::string results_file_name_;
     boost::nowide::ofstream results_file_stream_;

--- a/lib/inc/pcp-test/test_connection_parameters.hpp
+++ b/lib/inc/pcp-test/test_connection_parameters.hpp
@@ -18,7 +18,8 @@ extern const std::string CONCURRENCY;
 extern const std::string ENDPOINTS_INCREMENT;
 extern const std::string CONCURRENCY_INCREMENT;
 extern const std::string WS_CONNECTION_TIMEOUT_MS;
-extern const std::string ASSOCIATION_TTL_S;
+extern const std::string ASSOCIATION_TIMEOUT_S;
+extern const std::string ASSOCIATION_REQUEST_TTL_S;
 extern const std::string PERSIST_CONNECTIONS;
 
 }  // namespace connection_test_parameters

--- a/lib/src/client.cc
+++ b/lib/src/client.cc
@@ -16,7 +16,9 @@ client::client(client_configuration cfg)
                  configuration.ca,
                  configuration.crt,
                  configuration.key,
-                 configuration.connection_timeout_ms}
+                 configuration.connection_timeout_ms,
+                 configuration.association_timeout_s,
+                 configuration.association_request_ttl_s}
 {
     connector.registerMessageCallback(
             schemas::request(),
@@ -37,7 +39,7 @@ void client::send_request(const message& request,
     try {
         connector.send(endpoints,
                        schemas::REQUEST_TYPE,
-                       configuration.message_timeout_s,
+                       configuration.message_ttl_s,
                        request.get_data());
         LOG_DEBUG("Sent request %1%", request.transaction());
     } catch (PCPClient::connection_error& e) {
@@ -51,7 +53,7 @@ void client::reply(const message& request)
     try {
         connector.send({request.sender()},
                        schemas::RESPONSE_TYPE,
-                       configuration.message_timeout_s,
+                       configuration.message_ttl_s,
                        request.get_data());
         LOG_DEBUG("Replied to request %1%", request.transaction());
     } catch (PCPClient::connection_error& e) {
@@ -69,7 +71,7 @@ void client::reply_with_error(const message& request,
     try {
         connector.send({request.sender()},
                        schemas::ERROR_TYPE,
-                       configuration.message_timeout_s,
+                       configuration.message_ttl_s,
                        std::move(data));
         LOG_DEBUG("Replied to request %1% with an error", request.transaction());
     } catch (PCPClient::connection_error& e) {

--- a/lib/src/client_configuration.cc
+++ b/lib/src/client_configuration.cc
@@ -14,7 +14,9 @@ namespace pcp_test {
 namespace fs = boost::filesystem;
 
 const long DEFAULT_CONNECTION_TIMEOUT_MS {100};
-const unsigned int DEFAULT_MESSAGE_TIMEOUT_S {5};
+const uint32_t DEFAULT_ASSOCIATION_TIMEOUT_S {15};
+const uint32_t DEFAULT_ASSOCIATION_REQUEST_TTL_S {10};
+const uint32_t DEFAULT_MESSAGE_TTL_S {5};
 
 static boost::format CERT_FILE_FORMAT {"%1%.example.com_%2%.pem"};
 
@@ -24,13 +26,17 @@ client_configuration::client_configuration(
         const std::vector <std::string>& broker_ws_uris_,
         const std::string& certificates_dir_,
         long connection_tmeout_ms_,
-        unsigned int message_timeout_s_)
+        uint32_t association_timeout_s_,
+        uint32_t association_request_ttl_s_,
+        uint32_t message_ttl_s_)
     : common_name {std::move(common_name_)},
       client_type(client_type_),
       broker_ws_uris(broker_ws_uris_),
       certificates_dir(certificates_dir_),
       connection_timeout_ms {std::move(connection_tmeout_ms_)},
-      message_timeout_s {std::move(message_timeout_s_)}
+      association_timeout_s {std::move(association_timeout_s_)},
+      association_request_ttl_s {std::move(association_request_ttl_s_)},
+      message_ttl_s {std::move(message_ttl_s_)}
 {
     update_cert_paths();
 }

--- a/lib/src/schemas.cc
+++ b/lib/src/schemas.cc
@@ -59,16 +59,17 @@ PCPClient::Schema connection_test_parameters()
 {
     PCPClient::Schema schema {CONNECTION_TEST_PARAMETERS, C_Type::Json};
 
-    schema.addConstraint(conn_par::NUM_RUNS,                 T_Constraint::Int, true);
-    schema.addConstraint(conn_par::INTER_RUN_PAUSE_MS,       T_Constraint::Int, true);
-    schema.addConstraint(conn_par::NUM_ENDPOINTS,            T_Constraint::Int, true);
-    schema.addConstraint(conn_par::INTER_ENDPOINT_PAUSE_MS,  T_Constraint::Int, true);
-    schema.addConstraint(conn_par::CONCURRENCY,              T_Constraint::Int, true);
-    schema.addConstraint(conn_par::ENDPOINTS_INCREMENT,      T_Constraint::Int, true);
-    schema.addConstraint(conn_par::CONCURRENCY_INCREMENT,    T_Constraint::Int, true);
-    schema.addConstraint(conn_par::WS_CONNECTION_TIMEOUT_MS, T_Constraint::Int, true);
-    schema.addConstraint(conn_par::ASSOCIATION_TTL_S,        T_Constraint::Int, true);
-    schema.addConstraint(conn_par::PERSIST_CONNECTIONS,      T_Constraint::Bool, true);
+    schema.addConstraint(conn_par::NUM_RUNS,                  T_Constraint::Int, true);
+    schema.addConstraint(conn_par::INTER_RUN_PAUSE_MS,        T_Constraint::Int, true);
+    schema.addConstraint(conn_par::NUM_ENDPOINTS,             T_Constraint::Int, true);
+    schema.addConstraint(conn_par::INTER_ENDPOINT_PAUSE_MS,   T_Constraint::Int, true);
+    schema.addConstraint(conn_par::CONCURRENCY,               T_Constraint::Int, true);
+    schema.addConstraint(conn_par::ENDPOINTS_INCREMENT,       T_Constraint::Int, true);
+    schema.addConstraint(conn_par::CONCURRENCY_INCREMENT,     T_Constraint::Int, true);
+    schema.addConstraint(conn_par::WS_CONNECTION_TIMEOUT_MS,  T_Constraint::Int, true);
+    schema.addConstraint(conn_par::ASSOCIATION_TIMEOUT_S,     T_Constraint::Int, true);
+    schema.addConstraint(conn_par::ASSOCIATION_REQUEST_TTL_S, T_Constraint::Int, true);
+    schema.addConstraint(conn_par::PERSIST_CONNECTIONS,       T_Constraint::Bool, true);
 
     return schema;
 }

--- a/lib/src/test_connection_parameters.cc
+++ b/lib/src/test_connection_parameters.cc
@@ -11,7 +11,8 @@ const std::string CONCURRENCY {"concurrency"};
 const std::string ENDPOINTS_INCREMENT {"endpoints-increment"};;
 const std::string CONCURRENCY_INCREMENT {"concurrency-increment"};
 const std::string WS_CONNECTION_TIMEOUT_MS {"ws-connection-timeout-ms"};
-const std::string ASSOCIATION_TTL_S {"association-ttl-s"};
+const std::string ASSOCIATION_TIMEOUT_S {"association-timeout-s"};
+const std::string ASSOCIATION_REQUEST_TTL_S {"association-request-ttl-s"};
 const std::string PERSIST_CONNECTIONS {"persist-connections"};
 
 }  // namespace connection_test_parameters

--- a/lib/tests/pcp-test_test.cc
+++ b/lib/tests/pcp-test_test.cc
@@ -30,7 +30,8 @@ SCENARIO("client ctor", "[configuration]")
     pcp_test::client_configuration cc {std::string("0000agent"),
                                        client_type,
                                        uris,
-                                       certs_path};
+                                       certs_path,
+                                       1000, 12, 5, 5};
 
     REQUIRE_NOTHROW(pcp_test::client {std::move(cc)});
 }


### PR DESCRIPTION
Allow configuring the timeout for the entire Association process for the
Connection test with the 'association-timeout-s' option.

The option for configuring the Association request ttl is now named
'association-request-ttl-s' instead of 'association-ttl-s'.

Using `association-timeout-s` to determine the timeout of each
connection task.

Updating docs.
