### PR TITLE
(PCP-414) Add client-loglevel configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ certificate files are explained in this [document](doc/certificates.md).
 ```
       -h [ --help ]                  produce help message
       -v [ --version ]               print the version and exit
-      --loglevel arg                 log level (none, trace, debug, info, warning, error, fatal)
+      --loglevel arg                 pcp-test log level (none, trace, debug, info, warning, error, fatal)
+      --client-loglevel arg          client lib log level (none, trace, debug, info, warning, error, fatal)
       --logfile arg                  log file
       --config-file arg              configuration file (mandatory);
                                      defaults to /etc/puppetlabs/pcp-test/pcp-test.conf
@@ -62,10 +63,11 @@ specified in the configuration file, without the double hyphen prefix.
 An example of configuration file is:
 ```
     {
-        "logfile"  : "~/logs/pcp-test.log",
-        "loglevel" : "trace",
-        "broker-ws-uris" : ["localhost",
-                            "broker.example.com"],
+        "logfile"         : "~/logs/pcp-test.log",
+        "loglevel"        : "trace",
+        "client-loglevel" : "info",
+        "broker-ws-uris"  : ["localhost",
+                             "broker.example.com"],
         "connection-test-parameters" : {
             "num-runs"                   : 1,
             "inter-run-pause-ms"         : 5000,

--- a/exe/pcp-test.cc
+++ b/exe/pcp-test.cc
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
         lth_log::colorize(boost::nowide::cerr);
         exit(EXIT_FAILURE);
     }
-    configuration::setup_logging(a_o.logfile, a_o.loglevel);
+    configuration::setup_logging(a_o.logfile, a_o.loglevel, a_o.client_loglevel);
 
     try {
         start(a_o);

--- a/lib/inc/pcp-test/application_options.hpp
+++ b/lib/inc/pcp-test/application_options.hpp
@@ -15,10 +15,11 @@ namespace pcp_test {
 
 struct application_options
 {
-    std::string test;           // the test that will be executed
-    std::string logfile;        // path to the log file
-    std::string loglevel;       // log level
-    std::string configfile;     // path to the configuration file
+    std::string test;             // the test that will be executed
+    std::string logfile;          // path to the log file
+    std::string loglevel;         // log level of pcp-test
+    std::string client_loglevel;  // log level of cpp-pcp-client
+    std::string configfile;       // path to the configuration file
 
     std::vector<std::string> broker_ws_uris;    // WS URIs of PCP brokers
     std::string certificates_dir;               // SSL certs dir
@@ -35,6 +36,7 @@ struct application_options
     {
         static std::set<std::string> option_names {"logfile",
                                                    "loglevel",
+                                                   "client-loglevel",
                                                    "configfile",
                                                    "broker-ws-uris",
                                                    "certificates-dir",

--- a/lib/inc/pcp-test/configuration.hpp
+++ b/lib/inc/pcp-test/configuration.hpp
@@ -12,8 +12,10 @@
 namespace pcp_test {
 namespace configuration {
 
-// Throw a std::out_of_range in case of invalid loglevel.
-void setup_logging(const std::string& logfile, const std::string& loglevel);
+// Throw a std::out_of_range in case of invalid log level.
+void setup_logging(const std::string& logfile,
+                   const std::string& loglevel,
+                   const std::string& client_loglevel);
 
 // Parse the command line arguments and return an
 // application_options instance.

--- a/lib/tests/configuration_test.cc
+++ b/lib/tests/configuration_test.cc
@@ -22,11 +22,11 @@ SCENARIO("configuration::setup_logging", "[configuration]") {
     auto log_file = (TEST_PATH / "test.log").string();
 
     SECTION("can setup leatherman's logging") {
-        REQUIRE_NOTHROW(configuration::setup_logging(log_file, "warning"));
+        REQUIRE_NOTHROW(configuration::setup_logging(log_file, "warning", "info"));
     }
 
     SECTION("correctly sets the log level"){
-        configuration::setup_logging(log_file, "fatal");
+        configuration::setup_logging(log_file, "fatal", "debug");
         REQUIRE(lth_log::get_level() == lth_log::log_level::fatal);
     }
 
@@ -118,6 +118,7 @@ SCENARIO("configuration::validate_application_options", "[configuration]") {
     application_options ao {};
     ao.test = "trivial";
     ao.loglevel = "info";
+    ao.client_loglevel = "debug";
     ao.configfile = (CONFIG_PATH / "good.json").string();
     ao.logfile = (CONFIG_PATH / "good.log").string();
     ao.broker_ws_uris = {"wss://localhost:8142/pcp/vNext",
@@ -137,6 +138,11 @@ SCENARIO("configuration::validate_application_options", "[configuration]") {
                           configuration_error);
     }
 
+    SECTION("throws a configuration_error in case of invalid client log level") {
+        ao.client_loglevel = "super_logging";
+        REQUIRE_THROWS_AS(configuration::validate_application_options(ao),
+                          configuration_error);
+    }
 
     SECTION("throws a configuration_error in case of bad WS URI") {
         SECTION("bad protocol") {


### PR DESCRIPTION
Adding new option to allow configuring the log level of cpp-pcp-client
separately from the application one.
