### PR TITLE
(PCP-522) Add a beaker acceptance setup

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -3,5 +3,5 @@ require 'rake/clean'
 desc 'Run acceptance tests'
 task :acceptance do
   # TODO: create your real acceptance tests and update this
-  system("beaker --tests tests/fake.rb")
+  system("beaker --hosts config/nodes/el7-vmpooler.cfg --tests tests --options-file config/options.rb --helper lib/helper.rb")
 end

--- a/acceptance/config/nodes/el7-slice.cfg
+++ b/acceptance/config/nodes/el7-slice.cfg
@@ -1,0 +1,29 @@
+---
+HOSTS:
+  pcp-test:
+    pe_dir: 
+    pe_ver: 
+    pe_upgrade_dir: 
+    pe_upgrade_ver: 
+    hypervisor: none
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    timesync: false
+    user: centos
+    roles:
+    - pcp_test
+  pcp-broker:
+    pe_dir: 
+    pe_ver: 
+    pe_upgrade_dir: 
+    pe_upgrade_ver: 
+    hypervisor: none
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    timesync: false
+    user: centos
+    roles:
+    - pcp_broker
+CONFIG:
+  nfs_server: none
+  consoleport: 443

--- a/acceptance/config/nodes/el7-vmpooler.cfg
+++ b/acceptance/config/nodes/el7-vmpooler.cfg
@@ -1,0 +1,26 @@
+---
+HOSTS:
+  pcp_test:
+    pe_dir: 
+    pe_ver: 
+    pe_upgrade_dir: 
+    pe_upgrade_ver: 
+    hypervisor: vmpooler
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    roles:
+    - pcp_test
+  pcp_broker:
+    pe_dir: 
+    pe_ver: 
+    pe_upgrade_dir: 
+    pe_upgrade_ver: 
+    hypervisor: vmpooler
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    roles:
+    - pcp_broker
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/options.rb
+++ b/acceptance/config/options.rb
@@ -1,0 +1,9 @@
+{
+  :pre_suite => [
+    'setup/common/010_InstallDependencies.rb',
+    'setup/common/020_InstallPCPTest.rb',
+    'setup/common/025_AddHostsEntries.rb',
+    'setup/common/030_UnpackTestCertificates.rb',
+    'setup/common/040_InstallPCPBroker.rb',
+  ],
+}

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -1,0 +1,1 @@
+$LOAD_PATH << File.expand_path(File.dirname(__FILE__))

--- a/acceptance/lib/pcp_broker/broker_helper.rb
+++ b/acceptance/lib/pcp_broker/broker_helper.rb
@@ -1,0 +1,46 @@
+require 'net/http'
+require 'openssl'
+require 'socket'
+require 'json'
+
+# Some helpers for working with a pcp-broker 'lein tk' instance
+
+def run_pcp_broker(host)
+  on(host, "cd /opt/puppet-git-repos/pcp-broker; export LEIN_ROOT=ok; lein tk </dev/null >/var/log/puppetlabs/pcp-broker.log 2>&1 &")
+  assert(port_open_within?(host, 8142, 60),
+         "pcp-broker port 8142 not open within 1 minutes of starting the broker")
+  broker_state = nil
+  attempts = 0
+  until broker_state == "running" or attempts == 100 do
+    broker_state = get_pcp_broker_status(host)
+    if broker_state != "running"
+      attempts += 1
+      sleep 0.5
+    end
+  end
+  assert_equal("running", broker_state, "Shortly after startup, pcp-broker should report its state as being 'running'")
+end
+
+def kill_pcp_broker(host)
+  on(host, "ps -C java -f | grep pcp-broker | sed 's/[^0-9]*//' | cut -d\\  -f1") do |result|
+    pid = result.stdout.chomp
+    if(pid != '')
+      on(host, "kill -9 #{pid}")
+    end
+  end
+end
+
+def get_pcp_broker_status(host)
+  uri = URI.parse("https://#{host}:8142/status/v1/services/broker-service")
+  begin
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    res = http.get(uri.request_uri)
+    document = JSON.load(res.body)
+    return document["state"]
+  rescue => e
+    puts e.inspect
+    return nil
+  end
+end

--- a/acceptance/lib/pcp_test/config_helper.rb
+++ b/acceptance/lib/pcp_test/config_helper.rb
@@ -1,0 +1,32 @@
+require 'json'
+
+module PcpTestConfigHelper
+  PCP_CERTS_TARGET_DIR='/opt/puppetlabs/pcp-certs'
+
+  def default_config_hash
+    pcp_test_config_defaults = Hash.new
+    pcp_test_config_defaults['logfile']                    = '/var/log/puppetlabs/pcp-test/pcp-test.log'
+    pcp_test_config_defaults['results-dir']                = '/var/log/puppetlabs/pcp-test/logs'
+    pcp_test_config_defaults['loglevel']                   = 'trace'
+    pcp_test_config_defaults['broker-ws-uris']             = ['wss://broker.example.com:8142/pcp/']
+    pcp_test_config_defaults['certificates-dir']           = PCP_CERTS_TARGET_DIR
+    pcp_test_config_defaults['connection-test-parameters'] = {
+      'num-runs'                  => 1,
+      'inter-run-pause-ms'        => 1000,
+      'concurrency'               => 2,
+      'num-endpoints'             => 10,
+      'inter-endpoint-pause-ms'   => 150,
+      'endpoints-increment'       => 0,
+      'concurrency-increment'     => 0,
+      'ws-connection-timeout-ms'  => 2000,
+      'association-request-ttl-s' => 5,
+      'association-timeout-s'     => 5
+    }
+    return pcp_test_config_defaults
+  end
+
+  def default_config_json
+    default_config_hash.to_json
+  end
+  module_function :default_config_hash, :default_config_json
+end

--- a/acceptance/setup/common/010_InstallDependencies.rb
+++ b/acceptance/setup/common/010_InstallDependencies.rb
@@ -1,0 +1,7 @@
+step 'Install Puppet to assist with setup' do
+  install_puppet_agent_on(hosts)
+end
+
+step 'Install java on pcp-broker' do
+  on(pcp_broker, puppet('resource package java-1.8.0-openjdk-devel ensure=present'))
+end

--- a/acceptance/setup/common/020_InstallPCPTest.rb
+++ b/acceptance/setup/common/020_InstallPCPTest.rb
@@ -1,0 +1,14 @@
+require 'pcp_test/config_helper'
+
+step 'Install pcp-test' do
+  extend PcpTestConfigHelper
+
+  # QENG-4205 - add CI for pcp-test
+  # Install from fileserver instead
+  on(pcp_test, puppet('resource package wget ensure=present'))
+  on(pcp_test, 'wget http://int-resources.ops.puppetlabs.net/QA_resources/pcp_test/pcp-test-building-1.el7.x86_64.rpm')
+  on(pcp_test, 'rpm -ivh pcp-test-building-1.el7.x86_64.rpm')
+
+  on(pcp_test, 'mkdir -p /var/log/puppetlabs/pcp-test')
+  on(pcp_test, 'mkdir -p /opt/puppetlabs/pcp-test/results')
+end

--- a/acceptance/setup/common/025_AddHostsEntries.rb
+++ b/acceptance/setup/common/025_AddHostsEntries.rb
@@ -1,0 +1,4 @@
+step 'Add hosts entry for broker.example.com' do
+  broker_ip_address = on(pcp_broker, 'facter ipaddress').stdout.chomp
+  on(pcp_test, puppet("apply -e \"host { 'broker.example.com' : ip => '#{broker_ip_address}'}\""))
+end

--- a/acceptance/setup/common/030_UnpackTestCertificates.rb
+++ b/acceptance/setup/common/030_UnpackTestCertificates.rb
@@ -1,0 +1,20 @@
+require 'pcp_test/config_helper.rb'
+extend PcpTestConfigHelper
+
+PCP_CERTS_ARCHIVE_NAME='pcp-certificates.tar.gz'
+PCP_CERTS_DIRECT_URL="https://github.com/puppetlabs/pcp-test/raw/master/test-resources/#{PCP_CERTS_ARCHIVE_NAME}"
+
+step 'Fetch standard test certificates' do
+  on(hosts, puppet('resource package wget ensure=present'))
+  on(hosts, "wget #{PCP_CERTS_DIRECT_URL}")
+end
+
+step "Unpack certificates to #{PCP_CERTS_TARGET_DIR}" do
+  apply_manifest_on(hosts, <<-MANIFEST)
+file{'#{PCP_CERTS_TARGET_DIR}':
+  ensure => 'directory',
+}
+MANIFEST
+  on(hosts, "tar xvf #{PCP_CERTS_ARCHIVE_NAME}")
+  on(hosts, "mv pcp-certificates/* #{PCP_CERTS_TARGET_DIR}/ && rm -rf pcp-certificates")
+end

--- a/acceptance/setup/common/040_InstallPCPBroker.rb
+++ b/acceptance/setup/common/040_InstallPCPBroker.rb
@@ -1,0 +1,24 @@
+require 'pcp_test/config_helper.rb'
+extend PcpTestConfigHelper
+
+step 'Fetch Puppet module for pcp-broker' do
+  on(pcp_broker, puppet('module install jstocks-pcp_broker'))
+end
+
+step 'Install pcp-broker' do
+    apply_manifest_on(pcp_broker, <<-MANIFEST)
+class { 'pcp_broker':
+  run_broker   => false,
+  ssl_cert     => '#{PCP_CERTS_TARGET_DIR}/broker.example.com_crt.pem',
+  ssl_key      => '#{PCP_CERTS_TARGET_DIR}/broker.example.com_key.pem',
+  ssl_ca_cert  => '#{PCP_CERTS_TARGET_DIR}/ca_crt.pem',
+  ssl_crl_path => '#{PCP_CERTS_TARGET_DIR}/ca_crl.pem',
+}
+MANIFEST
+
+  on(pcp_broker, puppet('apply -e "file { \'/var/log/puppetlabs\': ensure => directory, }"'))
+end
+
+step 'Run lein deps to download Clojure dependencies' do
+  on(pcp_broker, 'cd /opt/puppet-git-repos/pcp-broker; export LEIN_ROOT=ok; lein deps')
+end

--- a/acceptance/tests/trivial_test.rb
+++ b/acceptance/tests/trivial_test.rb
@@ -1,0 +1,26 @@
+require 'pcp_test/config_helper.rb'
+require 'pcp_broker/broker_helper.rb'
+
+test_name 'Ensure that the trivial test mode works' do
+  extend PcpTestConfigHelper
+
+  teardown do
+    kill_pcp_broker(pcp_broker)
+  end
+
+  step 'Create a default config file' do
+    create_remote_file(pcp_test, 'pcp-test.conf', default_config_json().to_s)
+  end
+ 
+  step '(Re)start the broker' do
+    kill_pcp_broker(pcp_broker)
+    run_pcp_broker(pcp_broker)
+  end
+ 
+  step 'Run the trivial test' do
+    on(pcp_test, "/opt/puppetlabs/pcp-test/bin/pcp-test trivial --config-file pcp-test.conf --certificates-dir #{PCP_CERTS_TARGET_DIR}",
+       :accept_all_exit_codes => true) do |cmd_result|
+      assert_equal(0, cmd_result.exit_code, 'Exit code from pcp-test trivial should be 0')
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an initial beaker setup to deploy pcp-test on one host, and pcp-broker on another.
Includes a test to assert that the trivial test mode of pcp-test is working.

NOTE: 
1. pcp-test is installed from a package taken from a fileserver, until we get CI for it running
2. The Rakefile needs updated to use rototiller. We probably want a ci:acceptance task to test builds of pcp-test and a ci:broker_testing task to execute performance tests against pcp-broker
3. The setup fetches the jstocks-pcp_broker module from the Puppet Forge. This needs updated so that the module code we use is from a puppetlabs repo
