### PR TITLE
(maint) Ensure acceptance uses standard ssh key

### DIFF
--- a/acceptance/config/options.rb
+++ b/acceptance/config/options.rb
@@ -6,4 +6,7 @@
     'setup/common/030_UnpackTestCertificates.rb',
     'setup/common/040_InstallPCPBroker.rb',
   ],
+  :ssh => {
+    :keys => ["~/.ssh/id_rsa-acceptance"],
+  },
 }


### PR DESCRIPTION
Update beaker options to include the standard acceptance RSA key

[skip ci]