### PR TITLE
(PCP-579) Have acceptance test against the build from CI

### DIFF
--- a/acceptance/config/options.rb
+++ b/acceptance/config/options.rb
@@ -1,4 +1,5 @@
 {
+  :type => 'foss',
   :pre_suite => [
     'setup/common/010_InstallDependencies.rb',
     'setup/common/020_InstallPCPTest.rb',

--- a/acceptance/setup/common/010_InstallDependencies.rb
+++ b/acceptance/setup/common/010_InstallDependencies.rb
@@ -1,4 +1,7 @@
 step 'Install Puppet to assist with setup' do
+  hosts.each do |host|
+    install_puppetlabs_dev_repo(host, 'puppet-agent', ENV['PUPPET_AGENT_SHA'], 'repo-config')
+  end
   install_puppet_agent_on(hosts)
 end
 

--- a/acceptance/setup/common/020_InstallPCPTest.rb
+++ b/acceptance/setup/common/020_InstallPCPTest.rb
@@ -3,12 +3,9 @@ require 'pcp_test/config_helper'
 step 'Install pcp-test' do
   extend PcpTestConfigHelper
 
-  # QENG-4205 - add CI for pcp-test
-  # Install from fileserver instead
-  on(pcp_test, puppet('resource package wget ensure=present'))
-  on(pcp_test, 'wget http://int-resources.ops.puppetlabs.net/QA_resources/pcp_test/pcp-test-building-1.el7.x86_64.rpm')
-  on(pcp_test, 'rpm -ivh pcp-test-building-1.el7.x86_64.rpm')
-
+  install_puppetlabs_dev_repo(pcp_test, 'pcp-test', ENV['SUITE_COMMIT'], 'repo-config')
+  install_package(pcp_test, 'pcp-test')
+  
   on(pcp_test, 'mkdir -p /var/log/puppetlabs/pcp-test')
   on(pcp_test, 'mkdir -p /opt/puppetlabs/pcp-test/results')
 end


### PR DESCRIPTION
The initial commit of acceptance tests were just a placeholder, and they ran against a hardcoded URL to a pcp-test installer.
This commit updates the acceptance setup to test against an environment specified build of pcp-test.
Because pcp-test depends on the libraries of the the version of puppet-agent it was built against, this commit also updates the puppet agent installation
to ensure that it installs the same version of puppet-agent that was used to build pcp-test.